### PR TITLE
Feat/GitHub action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
 FROM amazoncorretto:17-alpine
 
-ARG JAR_FILE=build/libs/*.jar
+# Gradle Wrapper 스크립트와 프로젝트 파일 복사
+COPY gradlew /app/
+COPY gradle /app/gradle/
+COPY build.gradle /app/
+COPY settings.gradle /app/
 
+# 의존성 다운로드를 위해 초기 빌드 실행
+WORKDIR /app
+RUN ./gradlew build || return 0
+
+# 애플리케이션 코드 및 리소스 복사
+COPY src /app/src
+
+# 실제로 빌드된 JAR 파일 복사
+ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
+# 애플리케이션 실행
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
"INPUT_SCRIPT_STOP" -e "INPUT_ENVS" -e "INPUT_DEBUG" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e
======CMD======
sudo docker stop airbnb-backend-demo
sudo docker rm airbnb-backend-demo
sudo docker run -it -d -p 8080:8080 --name airbnb-backend-demo ***/airbnb-backend-demo
======END======
out: airbnb-backend-demo
out: airbnb-backend-demo
out: 78569acb7a014a289ad615ad60bf57c26364ecc182d282c3fd6edab090c9bb3b
err: docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./gradlew": stat ./gradlew: no such file or directory: unknown.
2024/04/11 04:31:27 Process exited with status 127

---
위의 에러 해결을 위해

Docker file에 Gradle Wrapper 스크립트와 Gradle 빌드된 JAR 파일을 Docker 이미지에 포함되도록 하는 코드 추가